### PR TITLE
chore: upgrade from Node 18 to Node 20

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           cache: npm
           cache-dependency-path: ./package.json
-          node-version: 18
+          node-version: 20
 
       - name: 📥 Install deps
         run: npm install
@@ -44,7 +44,7 @@ jobs:
         with:
           cache: npm
           cache-dependency-path: ./package.json
-          node-version: 18
+          node-version: 20
 
       - name: 📥 Install deps
         run: npm install
@@ -64,7 +64,7 @@ jobs:
         with:
           cache: npm
           cache-dependency-path: ./package.json
-          node-version: 18
+          node-version: 20
 
       - name: 📥 Install deps
         run: npm install
@@ -87,7 +87,7 @@ jobs:
         with:
           cache: npm
           cache-dependency-path: ./package.json
-          node-version: 18
+          node-version: 20
 
       - name: 📥 Install deps
         run: npm install

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # base node image
-FROM node:18-bullseye-slim as base
+FROM node:20-bookworm-slim as base
 
 # set for base and all layer that inherit from it
 ENV NODE_ENV production

--- a/app/routes/games/$gameid.test.tsx
+++ b/app/routes/games/$gameid.test.tsx
@@ -1,8 +1,6 @@
 import { loader, action } from "./$gameId";
 import { getGame, reopenGame, createGame } from "~/models/game.server";
 
-import { redirect } from "@remix-run/server-runtime";
-
 vi.mock("~/session.server", () => {
   return {
     requireUserId: vi.fn().mockResolvedValue("xxx"),
@@ -100,7 +98,8 @@ describe("action function for reopen game", () => {
   });
 
   test("returns a redirect response", () => {
-    expect(actionResponse).toEqual(redirect("/games/123/play/1"));
+    expect(actionResponse.status).toEqual(302);
+    expect(actionResponse.headers.get("Location")).toEqual("/games/123/play/1");
   });
 
   test("should reopen the game", () => {
@@ -130,7 +129,8 @@ describe("action function for rematch game", () => {
   });
 
   test("returns a redirect response", () => {
-    expect(actionResponse).toEqual(redirect("/games/567/play/1"));
+    expect(actionResponse.status).toEqual(302);
+    expect(actionResponse.headers.get("Location")).toEqual("/games/567/play/1");
   });
 
   test("should create a new game", () => {

--- a/app/routes/games/new.test.tsx
+++ b/app/routes/games/new.test.tsx
@@ -1,6 +1,5 @@
 import { loader, action } from "./new";
 import type { LoaderData } from "./new";
-import { redirect } from "@remix-run/server-runtime";
 
 import { getAllPlayers, createGame } from "~/models/game.server";
 
@@ -70,6 +69,7 @@ describe("start new game function", () => {
   });
 
   test("redirects to the play page after", () => {
-    expect(actionResponse).toEqual(redirect("/games/736/play/1"));
+    expect(actionResponse.status).toEqual(302);
+    expect(actionResponse.headers.get("Location")).toEqual("/games/736/play/1");
   });
 });

--- a/cypress/support/create-user.ts
+++ b/cypress/support/create-user.ts
@@ -5,11 +5,8 @@
 // as that new user.
 
 import { parse } from "cookie";
-import { installGlobals } from "@remix-run/node";
 import { createUserSession } from "~/session.server";
 import { createUser } from "~/models/user.server";
-
-installGlobals();
 
 async function createAndLogin(email: string) {
   if (!email) {

--- a/cypress/support/delete-user.ts
+++ b/cypress/support/delete-user.ts
@@ -4,10 +4,7 @@
 // and that user will get deleted
 
 import { PrismaClientKnownRequestError } from "@prisma/client/runtime/library";
-import { installGlobals } from "@remix-run/node";
 import { prisma } from "~/db.server";
-
-installGlobals();
 
 async function deleteUser(email: string) {
   if (!email) {

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "vitest": "^1.4.0"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "prisma": {
     "seed": "tsx prisma/seed.ts"


### PR DESCRIPTION
## Summary

Node 18 is approaching EOL. This upgrades all infrastructure to Node 20.

## Changes

- **Dockerfile**: `node:18-bullseye-slim` → `node:20-bookworm-slim` (Bookworm is current Debian stable)
- **CI (deploy.yml)**: `node-version: 18` → `20` across all 4 jobs
- **package.json**: `engines.node` bumped from `>=18` to `>=20`
- **Cypress support scripts**: Removed `installGlobals()` — Node 20 provides native `fetch`, `Request`, `Response`, etc.
- **Test assertions**: Replaced `toEqual(redirect(...))` with individual checks on `status` and `headers.get("Location")` — the deep-equality pattern breaks under Node 20's stricter `URLSearchParams` `this`-binding

## Verification

- 56/56 Vitest tests passing
- Lint, typecheck, and format all clean
- CI will validate end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)