### PR TITLE
fix: address PR #19 self-review findings

### DIFF
--- a/app/components/GameTypeSection.tsx
+++ b/app/components/GameTypeSection.tsx
@@ -1,0 +1,43 @@
+import { Form } from "@remix-run/react";
+
+export function GameTypeSection({
+  gameType,
+  gameTypes,
+}: {
+  gameType: { id: string; name: string } | null;
+  gameTypes: { id: string; name: string }[];
+}) {
+  if (gameType) {
+    return (
+      <h2 className="mb-2 text-xl font-bold dark:text-gray-100">
+        {gameType.name}
+      </h2>
+    );
+  }
+
+  if (gameTypes.length > 0) {
+    return (
+      <Form method="post" className="mb-4">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-sm font-medium dark:text-gray-300">
+            Set game type:
+          </span>
+          {gameTypes.map((gt) => (
+            <button
+              key={gt.id}
+              type="submit"
+              name="gameTypeId"
+              value={gt.id}
+              className="rounded bg-blue-primary px-3 py-1 text-sm text-white hover:bg-blue-600 dark:bg-blue-700 dark:hover:bg-blue-600"
+            >
+              {gt.name}
+            </button>
+          ))}
+        </div>
+        <input type="hidden" name="action" value="set-game-type" />
+      </Form>
+    );
+  }
+
+  return null;
+}

--- a/app/routes/games/$gameId.play.$playerId.tsx
+++ b/app/routes/games/$gameId.play.$playerId.tsx
@@ -20,6 +20,7 @@ import { json } from "@remix-run/node";
 import { getNextPlayerToPlay } from "~/game-utils";
 import { requireUserId } from "~/session.server";
 import { useEffect, useState } from "react";
+import { GameTypeSection } from "~/components/GameTypeSection";
 
 export type LoaderData = typeof loader;
 
@@ -130,31 +131,7 @@ export default function Play() {
 
   return (
     <>
-      {game.gameType ? (
-        <h2 className="mb-4 text-xl font-bold dark:text-gray-100">
-          {game.gameType.name}
-        </h2>
-      ) : gameTypes.length > 0 ? (
-        <Form method="post" className="mb-4">
-          <div className="flex flex-wrap items-center gap-2">
-            <span className="text-sm font-medium dark:text-gray-300">
-              Set game type:
-            </span>
-            {gameTypes.map((gt) => (
-              <button
-                key={gt.id}
-                type="submit"
-                name="gameTypeId"
-                value={gt.id}
-                className="rounded bg-blue-primary px-3 py-1 text-sm text-white hover:bg-blue-600 dark:bg-blue-700 dark:hover:bg-blue-600"
-              >
-                {gt.name}
-              </button>
-            ))}
-          </div>
-          <input type="hidden" name="action" value="set-game-type" />
-        </Form>
-      ) : null}
+      <GameTypeSection gameType={game.gameType} gameTypes={gameTypes} />
       <div className="mb-8 flex flex-row gap-2 text-center md:gap-4">
         {game.players.map((player) => (
           <div

--- a/app/routes/games/$gameId.tsx
+++ b/app/routes/games/$gameId.tsx
@@ -19,6 +19,7 @@ import {
 } from "~/models/game.server";
 import { getNextPlayerToPlay } from "~/game-utils";
 import { requireUserId } from "~/session.server";
+import { GameTypeSection } from "~/components/GameTypeSection";
 
 const english_ordinal_rules = new Intl.PluralRules("en", { type: "ordinal" });
 const suffixes = {
@@ -136,31 +137,7 @@ export default function GamePage() {
 
   return (
     <div className="flex flex-1 flex-col">
-      {game.gameType ? (
-        <h2 className="mb-2 text-xl font-bold dark:text-gray-100">
-          {game.gameType.name}
-        </h2>
-      ) : gameTypes.length > 0 ? (
-        <Form method="post" className="mb-4">
-          <div className="flex flex-wrap items-center gap-2">
-            <span className="text-sm font-medium dark:text-gray-300">
-              Set game type:
-            </span>
-            {gameTypes.map((gt) => (
-              <button
-                key={gt.id}
-                type="submit"
-                name="gameTypeId"
-                value={gt.id}
-                className="rounded bg-blue-primary px-3 py-1 text-sm text-white hover:bg-blue-600 dark:bg-blue-700 dark:hover:bg-blue-600"
-              >
-                {gt.name}
-              </button>
-            ))}
-          </div>
-          <input type="hidden" name="action" value="set-game-type" />
-        </Form>
-      ) : null}
+      <GameTypeSection gameType={game.gameType} gameTypes={gameTypes} />
       <h2 className="text-3xl dark:text-gray-100">{title}</h2>
       <div className="my-8 flex justify-around dark:text-gray-200">
         <div>

--- a/cypress/e2e/assign-game-type.cy.ts
+++ b/cypress/e2e/assign-game-type.cy.ts
@@ -1,5 +1,3 @@
-import { faker } from "@faker-js/faker";
-
 describe("Assign game type to existing game", () => {
   afterEach(() => {
     cy.cleanupUser();
@@ -23,7 +21,9 @@ describe("Assign game type to existing game", () => {
     cy.findByText("Set game type:").should("be.visible");
 
     // Select the game type
-    cy.get('button[name="gameTypeId"]').first().should("be.visible").click();
+    cy.intercept("POST", "**/games/**").as("setGameType");
+    cy.findByRole("button", { name: "Scrabble" }).should("be.visible").click();
+    cy.wait("@setGameType");
 
     // The assignment UI should be replaced by the game type heading
     cy.findByText("Set game type:").should("not.exist");
@@ -43,7 +43,7 @@ describe("Assign game type to existing game", () => {
 
     // Select an existing game type
     cy.intercept("POST", "**/play/**").as("setGameType");
-    cy.get('button[name="gameTypeId"]').first().should("be.visible").click();
+    cy.findByRole("button", { name: "Sushi Go" }).should("be.visible").click();
     cy.wait("@setGameType");
 
     // The assignment UI should be replaced by the game type heading

--- a/openspec/changes/assign-game-type/tasks.md
+++ b/openspec/changes/assign-game-type/tasks.md
@@ -1,25 +1,24 @@
 ## 1. Server Model
 
 - [x] 1.1 Add `setGameType` function to `app/models/game.server.ts` that updates a game's `gameTypeId` — only when the game belongs to the user and currently has no game type (`gameTypeId: null`)
-- [x] 1.2 Add unit test for `setGameType` in `app/models/game.server.test.ts` covering: successful set on typeless game, no-op on game that already has a type
+- [x] 1.2 Add unit test for `setGameType` in `app/models/game.server.test.ts` covering: successful set on typeless game, null guard prevents overwriting existing type
 
 ## 2. Game Summary Page (`games/$gameId.tsx`)
 
 - [x] 2.1 Update loader to fetch user's game types (via `getAllGameTypes`) when the game has no game type — requires adding `requireUserId` to the loader
 - [x] 2.2 Add `set-game-type` action case that calls `setGameType` with the selected game type ID
-- [x] 2.3 Add `add-and-set-game-type` action case that creates a new game type via `addGameType` and then calls `setGameType` to assign it to the game
-- [x] 2.4 Add game type assignment UI — when `game.gameType` is null, show a section with radio buttons for existing game types plus an inline "add new game type" form. When `game.gameType` exists, show the existing read-only heading
+- [x] 2.3 Add game type assignment UI — when `game.gameType` is null, show buttons for existing game types. When `game.gameType` exists, show the existing read-only heading
 
 ## 3. Play Screen (`games/$gameId.play.$playerId.tsx`)
 
 - [x] 3.1 Update loader to fetch user's game types when the game has no game type
-- [x] 3.2 Add `set-game-type` and `add-and-set-game-type` action cases matching the summary page pattern
-- [x] 3.3 Add game type assignment UI matching the summary page pattern — show assignment section when `game.gameType` is null, read-only heading when set
+- [x] 3.2 Add `set-game-type` action case matching the summary page pattern
+- [x] 3.3 Add game type assignment UI matching the summary page pattern — show assignment buttons when `game.gameType` is null, read-only heading when set
 
 ## 4. End-to-End Tests
 
 - [x] 4.1 Add Cypress e2e test: create a game without a game type, navigate to the game summary, assign an existing game type, verify the type heading appears
-- [x] 4.2 Add Cypress e2e test: create a game without a game type, navigate to the play screen, create a new game type inline and assign it, verify the type heading appears
+- [x] 4.2 Add Cypress e2e test: create a game without a game type, navigate to the play screen, assign an existing game type, verify the type heading appears
 - [x] 4.3 Add Cypress e2e test: verify that the assignment UI does not appear on games that already have a game type
 
 ## 5. Validation


### PR DESCRIPTION
## Why

Self-review of PR #19 identified duplicated UI code, inconsistent e2e test patterns, missing test coverage, and stale documentation. These issues should be resolved before merging the feature branch.

## Summary

- **Extract shared `GameTypeSection` component** — the identical game type ternary (heading / assignment form / null) was duplicated across both routes; now lives in `app/components/GameTypeSection.tsx`. Aligns both routes on `mb-2` for the heading.
- **Add `setGameType` null-guard unit test** — verifies the `gameTypeId: null` where clause is always sent to Prisma, preventing overwrites.
- **Fix e2e test inconsistencies** — summary test now uses `cy.intercept` + `cy.wait` (matching the play screen pattern); both tests use `cy.findByRole` instead of `cy.get('button[name=...]')`.
- **Remove unused `faker` import** from e2e test (caught by lint).
- **Update stale `tasks.md`** — removed references to descoped `add-and-set-game-type` actions and updated descriptions to match actual implementation (buttons, not radio buttons).

## Test plan

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run format` clean
- [x] `npm run test -- --run` — all 62 unit tests pass
- [ ] `npx cypress run --spec cypress/e2e/assign-game-type.cy.ts` — verify e2e tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)