### PR TITLE
fix: reset show/hide scores toggle when navigating between games

### DIFF
--- a/app/components/ScoreTable.tsx
+++ b/app/components/ScoreTable.tsx
@@ -1,4 +1,4 @@
-interface ScoreTablePlayer {
+export interface ScoreTablePlayer {
   id: string;
   name: string;
   scores: { id: string; points: number }[];

--- a/app/routes/games/$gameId.tsx
+++ b/app/routes/games/$gameId.tsx
@@ -6,7 +6,7 @@ import {
   useRouteError,
 } from "@remix-run/react";
 import { json, redirect } from "@remix-run/node";
-import { useRef, useState } from "react";
+import { useState, useRef } from "react";
 import invariant from "tiny-invariant";
 
 import {
@@ -20,7 +20,49 @@ import {
 import { getNextPlayerToPlay } from "~/game-utils";
 import { requireUserId } from "~/session.server";
 import { GameTypeSection } from "~/components/GameTypeSection";
-import { ScoreTable } from "~/components/ScoreTable";
+import { ScoreTable, type ScoreTablePlayer } from "~/components/ScoreTable";
+
+function CollapsibleScores({
+  players,
+  topScore,
+}: {
+  players: ScoreTablePlayer[];
+  topScore: number;
+}) {
+  const [showScores, setShowScores] = useState(false);
+
+  return (
+    <div className="mb-6">
+      <button
+        type="button"
+        onClick={() => setShowScores((prev) => !prev)}
+        className="flex w-full items-center justify-center gap-2 rounded bg-gray-100 py-2 px-4 text-sm font-medium text-gray-700 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
+      >
+        <svg
+          className={`h-4 w-4 transition-transform ${
+            showScores ? "rotate-180" : ""
+          }`}
+          fill="none"
+          viewBox="0 0 24 24"
+          strokeWidth={2}
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M19.5 8.25l-7.5 7.5-7.5-7.5"
+          />
+        </svg>
+        {showScores ? "Hide scores" : "Show scores"}
+      </button>
+      {showScores && (
+        <div className="mt-3">
+          <ScoreTable players={players} topScore={topScore} />
+        </div>
+      )}
+    </div>
+  );
+}
 
 const english_ordinal_rules = new Intl.PluralRules("en", { type: "ordinal" });
 const suffixes = {
@@ -123,7 +165,6 @@ export const action = async ({ request, params }: ActionFunctionArgs) => {
 export default function GamePage() {
   const { game, winners, topScore, gameTypes } = useLoaderData<typeof loader>();
   const dialogRef = useRef<HTMLDialogElement>(null);
-  const [showScores, setShowScores] = useState(false);
   let title = "Still Playing";
 
   if (game.completed) {
@@ -161,35 +202,11 @@ export default function GamePage() {
         </div>
       </div>
       {game.completed && (
-        <div className="mb-6">
-          <button
-            type="button"
-            onClick={() => setShowScores((prev) => !prev)}
-            className="flex w-full items-center justify-center gap-2 rounded bg-gray-100 py-2 px-4 text-sm font-medium text-gray-700 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
-          >
-            <svg
-              className={`h-4 w-4 transition-transform ${
-                showScores ? "rotate-180" : ""
-              }`}
-              fill="none"
-              viewBox="0 0 24 24"
-              strokeWidth={2}
-              stroke="currentColor"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M19.5 8.25l-7.5 7.5-7.5-7.5"
-              />
-            </svg>
-            {showScores ? "Hide scores" : "Show scores"}
-          </button>
-          {showScores && (
-            <div className="mt-3">
-              <ScoreTable players={game.players} topScore={topScore} />
-            </div>
-          )}
-        </div>
+        <CollapsibleScores
+          key={game.id}
+          players={game.players}
+          topScore={topScore}
+        />
       )}
       {game.completed && (
         <>


### PR DESCRIPTION
## Why

When navigating between completed games, the "Show scores" / "Hide scores" toggle retains its state from the previous game. If you expand scores on one game then navigate to another, the scores section stays expanded — which feels wrong since you're viewing a different game.

The root cause is that Remix reuses the same route component instance when navigating between `/games/abc` and `/games/def` (same route, different param). React preserves `useState` across these navigations instead of reinitializing it.

## How

Extract the collapsible scores section into a `CollapsibleScores` child component rendered with `key={game.id}`. When the game ID changes, React unmounts the old instance and mounts a fresh one, naturally resetting `showScores` back to `false`.

## Test plan

- [ ] Navigate to a completed game and expand scores — toggle works as before
- [ ] Navigate to a different completed game — scores section is collapsed (not carried over)
- [ ] Toggle still works correctly on the new game

🤖 Generated with [Claude Code](https://claude.com/claude-code)