### PR TITLE
chore: replace as any casts in test mocks with typed objects

### DIFF
--- a/app/models/game.server.test.ts
+++ b/app/models/game.server.test.ts
@@ -15,15 +15,42 @@ vi.mock("~/db.server", () => {
       game: {
         findFirst: vi.fn().mockResolvedValue({
           id: "123",
+          completed: false,
+          createdAt: new Date("2026-01-01"),
+          gameType: null,
           players: [
-            { id: 1, totalScore: 11 },
-            { id: 2, totalScore: 22 },
+            { id: "1", name: "Player 1", userId: "user-1" },
+            { id: "2", name: "Player 2", userId: "user-1" },
           ],
           scores: [
-            { playerId: 1, points: 1 },
-            { playerId: 2, points: 2 },
-            { playerId: 1, points: 10 },
-            { playerId: 2, points: 20 },
+            {
+              id: "sc1",
+              playerId: "1",
+              gameId: "123",
+              points: 1,
+              scoredAt: new Date("2026-01-01"),
+            },
+            {
+              id: "sc2",
+              playerId: "2",
+              gameId: "123",
+              points: 2,
+              scoredAt: new Date("2026-01-01"),
+            },
+            {
+              id: "sc3",
+              playerId: "1",
+              gameId: "123",
+              points: 10,
+              scoredAt: new Date("2026-01-01"),
+            },
+            {
+              id: "sc4",
+              playerId: "2",
+              gameId: "123",
+              points: 20,
+              scoredAt: new Date("2026-01-01"),
+            },
           ],
         }),
         update: vi.fn().mockResolvedValue({ id: "123", gameTypeId: "gt-1" }),
@@ -82,15 +109,40 @@ describe("game.server getLastCompletedGame", () => {
       createdAt: new Date("2026-01-01"),
       gameType: { id: "gt-1", name: "Scrabble" },
       players: [
-        { id: "p1", name: "Alice" },
-        { id: "p2", name: "Bob" },
+        { id: "p1", name: "Alice", userId: "user-1" },
+        { id: "p2", name: "Bob", userId: "user-1" },
       ],
       scores: [
-        { playerId: "p1", points: 30 },
-        { playerId: "p2", points: 50 },
-        { playerId: "p1", points: 20 },
-        { playerId: "p2", points: 10 },
+        {
+          id: "s1",
+          playerId: "p1",
+          gameId: "456",
+          points: 30,
+          scoredAt: new Date("2026-01-01"),
+        },
+        {
+          id: "s2",
+          playerId: "p2",
+          gameId: "456",
+          points: 50,
+          scoredAt: new Date("2026-01-01"),
+        },
+        {
+          id: "s3",
+          playerId: "p1",
+          gameId: "456",
+          points: 20,
+          scoredAt: new Date("2026-01-01"),
+        },
+        {
+          id: "s4",
+          playerId: "p2",
+          gameId: "456",
+          points: 10,
+          scoredAt: new Date("2026-01-01"),
+        },
       ],
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Prisma's generic return type doesn't narrow through mocks
     } as any);
 
     const result = await getLastCompletedGame({ userId: "user-1" });
@@ -158,9 +210,10 @@ describe("game.server getTopGameTypes", () => {
 
   test("returns game types ranked by count", async () => {
     vi.mocked(prisma.gameType.findMany).mockResolvedValueOnce([
-      { id: "gt-1", name: "Scrabble", userId: "user-1", _count: { games: 5 } },
-      { id: "gt-2", name: "Words", userId: "user-1", _count: { games: 3 } },
-      { id: "gt-3", name: "Empty", userId: "user-1", _count: { games: 0 } },
+      { id: "gt-1", name: "Scrabble", _count: { games: 5 } },
+      { id: "gt-2", name: "Words", _count: { games: 3 } },
+      { id: "gt-3", name: "Empty", _count: { games: 0 } },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Prisma's generic return type doesn't narrow through mocks
     ] as any);
 
     const result = await getTopGameTypes({ userId: "user-1", limit: 3 });
@@ -205,6 +258,7 @@ describe("game.server getTopPlayers", () => {
       },
       { id: "p2", name: "Bob", games: [{ id: "g1" }, { id: "g2" }] },
       { id: "p3", name: "Carol", games: [{ id: "g1" }] },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Prisma's generic return type doesn't narrow through mocks
     ] as any);
 
     const result = await getTopPlayers({ userId: "user-1", limit: 3 });
@@ -220,6 +274,7 @@ describe("game.server getTopPlayers", () => {
     vi.mocked(prisma.player.findMany).mockResolvedValueOnce([
       { id: "p1", name: "Alice", games: [{ id: "g1" }] },
       { id: "p2", name: "Bob", games: [] },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Prisma's generic return type doesn't narrow through mocks
     ] as any);
 
     const result = await getTopPlayers({ userId: "user-1" });

--- a/app/routes/games/$gameid.test.tsx
+++ b/app/routes/games/$gameid.test.tsx
@@ -17,12 +17,25 @@ vi.mock("~/models/game.server", () => {
     reopenGame: vi.fn(),
     getAllGameTypes: vi.fn().mockResolvedValue([]),
     getGame: vi.fn().mockResolvedValue({
-      id: 1,
+      id: "1",
       completed: false,
+      createdAt: new Date("2026-01-01"),
       gameType: null,
       players: [
-        { id: 1, name: "alice", totalScore: 5 },
-        { id: 2, name: "nina", totalScore: 2 },
+        {
+          id: "1",
+          name: "alice",
+          userId: "xxx",
+          scores: [],
+          totalScore: 5,
+        },
+        {
+          id: "2",
+          name: "nina",
+          userId: "xxx",
+          scores: [],
+          totalScore: 2,
+        },
       ],
       scores: [],
     }),
@@ -36,15 +49,28 @@ describe("loader function for completed game", () => {
 
   beforeEach(async () => {
     vi.mocked(getGame).mockResolvedValueOnce({
-      id: 1,
+      id: "1",
       completed: true,
+      createdAt: new Date("2026-01-01"),
       gameType: null,
       players: [
-        { id: 1, name: "alice", totalScore: 5 },
-        { id: 2, name: "nina", totalScore: 2 },
+        {
+          id: "1",
+          name: "alice",
+          userId: "xxx",
+          scores: [],
+          totalScore: 5,
+        },
+        {
+          id: "2",
+          name: "nina",
+          userId: "xxx",
+          scores: [],
+          totalScore: 2,
+        },
       ],
       scores: [],
-    } as any);
+    });
 
     loaderResponse = await loader({
       request: new Request("https://url"),
@@ -65,12 +91,27 @@ describe("loader function for completed game", () => {
     const data = await loaderResponse.json();
 
     expect(data.game).toEqual({
-      id: 1,
+      id: "1",
       completed: true,
+      createdAt: "2026-01-01T00:00:00.000Z",
       gameType: null,
       players: [
-        { id: 1, name: "alice", totalScore: 5, place: 1 },
-        { id: 2, name: "nina", totalScore: 2, place: 2 },
+        {
+          id: "1",
+          name: "alice",
+          userId: "xxx",
+          scores: [],
+          totalScore: 5,
+          place: 1,
+        },
+        {
+          id: "2",
+          name: "nina",
+          userId: "xxx",
+          scores: [],
+          totalScore: 2,
+          place: 2,
+        },
       ],
       scores: [],
     });
@@ -81,7 +122,14 @@ describe("loader function for completed game", () => {
 
     expect(data.winners.length).toEqual(1);
     expect(data.winners).toEqual([
-      { id: 1, name: "alice", totalScore: 5, place: 1 },
+      {
+        id: "1",
+        name: "alice",
+        userId: "xxx",
+        scores: [],
+        totalScore: 5,
+        place: 1,
+      },
     ]);
   });
 
@@ -169,7 +217,7 @@ describe("action function for rematch game", () => {
   test("should create a new game", () => {
     expect(createGame).toHaveBeenCalledWith({
       userId: "xxx",
-      players: [1, 2],
+      players: ["1", "2"],
       gameTypeId: null,
     });
   });

--- a/app/routes/games/players.$playerId.test.tsx
+++ b/app/routes/games/players.$playerId.test.tsx
@@ -4,37 +4,6 @@ vi.mock("~/session.server", () => ({
   requireUserId: vi.fn().mockResolvedValue("user-1"),
 }));
 
-const gameTypeScrabble = { id: "gt-scrabble", name: "Scrabble" };
-const gameTypeSushiGo = { id: "gt-sushi", name: "Sushi Go" };
-
-const players = [
-  { id: "p1", name: "Alice" },
-  { id: "p2", name: "Bob" },
-];
-
-function makeGame({
-  id,
-  completed = true,
-  gameType = gameTypeScrabble,
-  scores = [],
-  createdAt = new Date("2026-01-15").toISOString(),
-}: {
-  id: string;
-  completed?: boolean;
-  gameType?: { id: string; name: string } | null;
-  scores?: { playerId: string; points: number }[];
-  createdAt?: string;
-}) {
-  return {
-    id,
-    completed,
-    gameType,
-    players,
-    scores,
-    createdAt,
-  };
-}
-
 vi.mock("~/models/game.server", () => ({
   getPlayer: vi.fn().mockResolvedValue({ id: "p1", name: "Alice" }),
   getPlayerGames: vi.fn().mockResolvedValue([]),
@@ -111,30 +80,87 @@ describe("players.$playerId loader", () => {
     const { getPlayerGames } = await import("~/models/game.server");
     vi.mocked(getPlayerGames).mockResolvedValueOnce([
       // Alice wins (higher score)
-      makeGame({
+      {
         id: "g1",
-        scores: [
-          { playerId: "p1", points: 100 },
-          { playerId: "p2", points: 80 },
+        completed: true,
+        createdAt: new Date("2026-01-15"),
+        gameType: { id: "gt-scrabble", name: "Scrabble" },
+        players: [
+          { id: "p1", name: "Alice", userId: "user-1" },
+          { id: "p2", name: "Bob", userId: "user-1" },
         ],
-      }),
+        scores: [
+          {
+            id: "s1",
+            playerId: "p1",
+            gameId: "g1",
+            points: 100,
+            scoredAt: new Date("2026-01-15"),
+          },
+          {
+            id: "s2",
+            playerId: "p2",
+            gameId: "g1",
+            points: 80,
+            scoredAt: new Date("2026-01-15"),
+          },
+        ],
+      },
       // Alice loses
-      makeGame({
+      {
         id: "g2",
-        scores: [
-          { playerId: "p1", points: 50 },
-          { playerId: "p2", points: 90 },
+        completed: true,
+        createdAt: new Date("2026-01-15"),
+        gameType: { id: "gt-scrabble", name: "Scrabble" },
+        players: [
+          { id: "p1", name: "Alice", userId: "user-1" },
+          { id: "p2", name: "Bob", userId: "user-1" },
         ],
-      }),
+        scores: [
+          {
+            id: "s3",
+            playerId: "p1",
+            gameId: "g2",
+            points: 50,
+            scoredAt: new Date("2026-01-15"),
+          },
+          {
+            id: "s4",
+            playerId: "p2",
+            gameId: "g2",
+            points: 90,
+            scoredAt: new Date("2026-01-15"),
+          },
+        ],
+      },
       // Tie — neither win nor loss
-      makeGame({
+      {
         id: "g3",
-        scores: [
-          { playerId: "p1", points: 75 },
-          { playerId: "p2", points: 75 },
+        completed: true,
+        createdAt: new Date("2026-01-15"),
+        gameType: { id: "gt-scrabble", name: "Scrabble" },
+        players: [
+          { id: "p1", name: "Alice", userId: "user-1" },
+          { id: "p2", name: "Bob", userId: "user-1" },
         ],
-      }),
-    ] as any);
+        scores: [
+          {
+            id: "s5",
+            playerId: "p1",
+            gameId: "g3",
+            points: 75,
+            scoredAt: new Date("2026-01-15"),
+          },
+          {
+            id: "s6",
+            playerId: "p2",
+            gameId: "g3",
+            points: 75,
+            scoredAt: new Date("2026-01-15"),
+          },
+        ],
+      },
+    ]);
 
     const response = await callLoader("p1");
     const data = await response.json();
@@ -148,23 +174,59 @@ describe("players.$playerId loader", () => {
   test("shows per-type stats when no type filter is selected", async () => {
     const { getPlayerGames } = await import("~/models/game.server");
     vi.mocked(getPlayerGames).mockResolvedValueOnce([
-      makeGame({
+      {
         id: "g1",
-        gameType: gameTypeScrabble,
-        scores: [
-          { playerId: "p1", points: 300 },
-          { playerId: "p2", points: 200 },
+        completed: true,
+        createdAt: new Date("2026-01-15"),
+        gameType: { id: "gt-scrabble", name: "Scrabble" },
+        players: [
+          { id: "p1", name: "Alice", userId: "user-1" },
+          { id: "p2", name: "Bob", userId: "user-1" },
         ],
-      }),
-      makeGame({
+        scores: [
+          {
+            id: "s1",
+            playerId: "p1",
+            gameId: "g1",
+            points: 300,
+            scoredAt: new Date("2026-01-15"),
+          },
+          {
+            id: "s2",
+            playerId: "p2",
+            gameId: "g1",
+            points: 200,
+            scoredAt: new Date("2026-01-15"),
+          },
+        ],
+      },
+      {
         id: "g2",
-        gameType: gameTypeSushiGo,
-        scores: [
-          { playerId: "p1", points: 40 },
-          { playerId: "p2", points: 30 },
+        completed: true,
+        createdAt: new Date("2026-01-15"),
+        gameType: { id: "gt-sushi", name: "Sushi Go" },
+        players: [
+          { id: "p1", name: "Alice", userId: "user-1" },
+          { id: "p2", name: "Bob", userId: "user-1" },
         ],
-      }),
-    ] as any);
+        scores: [
+          {
+            id: "s3",
+            playerId: "p1",
+            gameId: "g2",
+            points: 40,
+            scoredAt: new Date("2026-01-15"),
+          },
+          {
+            id: "s4",
+            playerId: "p2",
+            gameId: "g2",
+            points: 30,
+            scoredAt: new Date("2026-01-15"),
+          },
+        ],
+      },
+    ]);
 
     const response = await callLoader("p1");
     const data = await response.json();
@@ -185,23 +247,59 @@ describe("players.$playerId loader", () => {
   test("filters stats by game type when type param is set", async () => {
     const { getPlayerGames } = await import("~/models/game.server");
     vi.mocked(getPlayerGames).mockResolvedValueOnce([
-      makeGame({
+      {
         id: "g1",
-        gameType: gameTypeScrabble,
-        scores: [
-          { playerId: "p1", points: 300 },
-          { playerId: "p2", points: 200 },
+        completed: true,
+        createdAt: new Date("2026-01-15"),
+        gameType: { id: "gt-scrabble", name: "Scrabble" },
+        players: [
+          { id: "p1", name: "Alice", userId: "user-1" },
+          { id: "p2", name: "Bob", userId: "user-1" },
         ],
-      }),
-      makeGame({
+        scores: [
+          {
+            id: "s1",
+            playerId: "p1",
+            gameId: "g1",
+            points: 300,
+            scoredAt: new Date("2026-01-15"),
+          },
+          {
+            id: "s2",
+            playerId: "p2",
+            gameId: "g1",
+            points: 200,
+            scoredAt: new Date("2026-01-15"),
+          },
+        ],
+      },
+      {
         id: "g2",
-        gameType: gameTypeSushiGo,
-        scores: [
-          { playerId: "p1", points: 40 },
-          { playerId: "p2", points: 30 },
+        completed: true,
+        createdAt: new Date("2026-01-15"),
+        gameType: { id: "gt-sushi", name: "Sushi Go" },
+        players: [
+          { id: "p1", name: "Alice", userId: "user-1" },
+          { id: "p2", name: "Bob", userId: "user-1" },
         ],
-      }),
-    ] as any);
+        scores: [
+          {
+            id: "s3",
+            playerId: "p1",
+            gameId: "g2",
+            points: 40,
+            scoredAt: new Date("2026-01-15"),
+          },
+          {
+            id: "s4",
+            playerId: "p2",
+            gameId: "g2",
+            points: 30,
+            scoredAt: new Date("2026-01-15"),
+          },
+        ],
+      },
+    ]);
 
     const response = await callLoader("p1", { type: "gt-scrabble" });
     const data = await response.json();
@@ -216,23 +314,59 @@ describe("players.$playerId loader", () => {
   test("includes in-progress games in history but not stats", async () => {
     const { getPlayerGames } = await import("~/models/game.server");
     vi.mocked(getPlayerGames).mockResolvedValueOnce([
-      makeGame({
+      {
         id: "g1",
         completed: true,
-        scores: [
-          { playerId: "p1", points: 100 },
-          { playerId: "p2", points: 80 },
+        createdAt: new Date("2026-01-15"),
+        gameType: { id: "gt-scrabble", name: "Scrabble" },
+        players: [
+          { id: "p1", name: "Alice", userId: "user-1" },
+          { id: "p2", name: "Bob", userId: "user-1" },
         ],
-      }),
-      makeGame({
+        scores: [
+          {
+            id: "s1",
+            playerId: "p1",
+            gameId: "g1",
+            points: 100,
+            scoredAt: new Date("2026-01-15"),
+          },
+          {
+            id: "s2",
+            playerId: "p2",
+            gameId: "g1",
+            points: 80,
+            scoredAt: new Date("2026-01-15"),
+          },
+        ],
+      },
+      {
         id: "g2",
         completed: false,
-        scores: [
-          { playerId: "p1", points: 50 },
-          { playerId: "p2", points: 30 },
+        createdAt: new Date("2026-01-15"),
+        gameType: { id: "gt-scrabble", name: "Scrabble" },
+        players: [
+          { id: "p1", name: "Alice", userId: "user-1" },
+          { id: "p2", name: "Bob", userId: "user-1" },
         ],
-      }),
-    ] as any);
+        scores: [
+          {
+            id: "s3",
+            playerId: "p1",
+            gameId: "g2",
+            points: 50,
+            scoredAt: new Date("2026-01-15"),
+          },
+          {
+            id: "s4",
+            playerId: "p2",
+            gameId: "g2",
+            points: 30,
+            scoredAt: new Date("2026-01-15"),
+          },
+        ],
+      },
+    ]);
 
     const response = await callLoader("p1");
     const data = await response.json();
@@ -246,23 +380,59 @@ describe("players.$playerId loader", () => {
   test("skips untyped games in per-type breakdown", async () => {
     const { getPlayerGames } = await import("~/models/game.server");
     vi.mocked(getPlayerGames).mockResolvedValueOnce([
-      makeGame({
+      {
         id: "g1",
-        gameType: gameTypeScrabble,
-        scores: [
-          { playerId: "p1", points: 300 },
-          { playerId: "p2", points: 200 },
+        completed: true,
+        createdAt: new Date("2026-01-15"),
+        gameType: { id: "gt-scrabble", name: "Scrabble" },
+        players: [
+          { id: "p1", name: "Alice", userId: "user-1" },
+          { id: "p2", name: "Bob", userId: "user-1" },
         ],
-      }),
-      makeGame({
+        scores: [
+          {
+            id: "s1",
+            playerId: "p1",
+            gameId: "g1",
+            points: 300,
+            scoredAt: new Date("2026-01-15"),
+          },
+          {
+            id: "s2",
+            playerId: "p2",
+            gameId: "g1",
+            points: 200,
+            scoredAt: new Date("2026-01-15"),
+          },
+        ],
+      },
+      {
         id: "g2",
+        completed: true,
+        createdAt: new Date("2026-01-15"),
         gameType: null,
-        scores: [
-          { playerId: "p1", points: 100 },
-          { playerId: "p2", points: 80 },
+        players: [
+          { id: "p1", name: "Alice", userId: "user-1" },
+          { id: "p2", name: "Bob", userId: "user-1" },
         ],
-      }),
-    ] as any);
+        scores: [
+          {
+            id: "s3",
+            playerId: "p1",
+            gameId: "g2",
+            points: 100,
+            scoredAt: new Date("2026-01-15"),
+          },
+          {
+            id: "s4",
+            playerId: "p2",
+            gameId: "g2",
+            points: 80,
+            scoredAt: new Date("2026-01-15"),
+          },
+        ],
+      },
+    ]);
 
     const response = await callLoader("p1");
     const data = await response.json();
@@ -277,21 +447,36 @@ describe("players.$playerId loader", () => {
   test("returns available game types from all games", async () => {
     const { getPlayerGames } = await import("~/models/game.server");
     vi.mocked(getPlayerGames).mockResolvedValueOnce([
-      makeGame({ id: "g1", gameType: gameTypeScrabble, scores: [] }),
-      makeGame({
+      {
+        id: "g1",
+        completed: true,
+        createdAt: new Date("2026-01-15"),
+        gameType: { id: "gt-scrabble", name: "Scrabble" },
+        players: [
+          { id: "p1", name: "Alice", userId: "user-1" },
+          { id: "p2", name: "Bob", userId: "user-1" },
+        ],
+        scores: [],
+      },
+      {
         id: "g2",
         completed: false,
-        gameType: gameTypeSushiGo,
+        createdAt: new Date("2026-01-15"),
+        gameType: { id: "gt-sushi", name: "Sushi Go" },
+        players: [
+          { id: "p1", name: "Alice", userId: "user-1" },
+          { id: "p2", name: "Bob", userId: "user-1" },
+        ],
         scores: [],
-      }),
-    ] as any);
+      },
+    ]);
 
     const response = await callLoader("p1");
     const data = await response.json();
 
     expect(data.availableGameTypes).toEqual([
-      gameTypeScrabble,
-      gameTypeSushiGo,
+      { id: "gt-scrabble", name: "Scrabble" },
+      { id: "gt-sushi", name: "Sushi Go" },
     ]);
   });
 });


### PR DESCRIPTION
## Why

Test mocks across the codebase used `as any` on return values, silencing TypeScript and allowing mocks to drift from real types without the compiler catching it (issue #43).

This was already causing real bugs: `$gameid.test.tsx` used numeric IDs (`id: 1`) while the actual types use strings, and `players.$playerId.test.tsx` used `.toISOString()` for `createdAt` when the real return type is `Date`.

## What changed

- **`players.$playerId.test.tsx`**: Removed the `makeGame` factory, shared `players` array, and shared gameType constants. Every test now defines its own complete inline mock objects with all required fields (`userId` on players, `id`/`gameId`/`scoredAt` on scores). 6 `as any` casts removed.

- **`$gameid.test.tsx`**: Fixed numeric IDs to strings, added missing fields (`userId`, `scores`, `createdAt` on players). Fixed the rematch assertion from `players: [1, 2]` to `players: ["1", "2"]`. 1 `as any` cast removed.

- **`game.server.test.ts`**: Added missing fields to all Prisma mock objects (full Score and Player scalar fields). 4 `as any` casts remain with `eslint-disable` comments — these are unavoidable because Prisma's generic return types don't narrow through `vi.mocked()`, but the objects are now structurally complete.

## Test plan

- [x] All 125 Vitest tests pass
- [x] TypeScript typecheck passes with zero errors
- [x] ESLint passes on all changed files

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)