### PR TITLE
Extract shared RecordCard component from compare page

### DIFF
--- a/app/components/ActionButton.tsx
+++ b/app/components/ActionButton.tsx
@@ -1,10 +1,16 @@
 type ActionButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement>;
 
-export function ActionButton({ children, className, ...props }: ActionButtonProps) {
+export function ActionButton({
+  children,
+  className,
+  ...props
+}: ActionButtonProps) {
   return (
     <button
       {...props}
-      className={`rounded-2xl border border-black bg-gray-100 p-2 text-gray-700 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-400 dark:bg-gray-800 dark:text-gray-200${className ? ` ${className}` : ""}`}
+      className={`rounded-2xl border border-black bg-gray-100 p-2 text-gray-700 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-400 dark:bg-gray-800 dark:text-gray-200${
+        className ? ` ${className}` : ""
+      }`}
     >
       {children}
     </button>

--- a/app/components/RecordCard.tsx
+++ b/app/components/RecordCard.tsx
@@ -1,0 +1,59 @@
+import { Card } from "~/components/Card";
+
+const colorClasses = {
+  blue: "text-blue-primary dark:text-blue-400",
+  green: "text-green-primary dark:text-green-400",
+} as const;
+
+interface RecordCardProps {
+  title: string;
+  p1Label: string | undefined;
+  p1Count: number;
+  p2Label: string | undefined;
+  p2Count: number;
+  draws: number;
+  color: keyof typeof colorClasses;
+}
+
+export function RecordCard({
+  title,
+  p1Label,
+  p1Count,
+  p2Label,
+  p2Count,
+  draws,
+  color,
+}: RecordCardProps) {
+  return (
+    <Card title={title}>
+      <div className="flex items-center justify-between">
+        <div className="text-center">
+          <div className="text-sm font-medium text-gray-600 dark:text-gray-400">
+            {p1Label}
+          </div>
+          <div className={`text-3xl font-bold ${colorClasses[color]}`}>
+            {p1Count}
+          </div>
+        </div>
+        <div className="text-2xl font-bold text-gray-400">-</div>
+        <div className="text-center">
+          <div className="text-sm font-medium text-gray-600 dark:text-gray-400">
+            {p2Label}
+          </div>
+          <div className={`text-3xl font-bold ${colorClasses[color]}`}>
+            {p2Count}
+          </div>
+        </div>
+        <div className="text-2xl font-bold text-gray-400">-</div>
+        <div className="text-center">
+          <div className="text-sm font-medium text-gray-600 dark:text-gray-400">
+            Draws
+          </div>
+          <div className="text-3xl font-bold text-gray-500 dark:text-gray-400">
+            {draws}
+          </div>
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/app/routes/anagram.tsx
+++ b/app/routes/anagram.tsx
@@ -93,7 +93,10 @@ export function removeLastOccurrence(stack: number[], value: number): number[] {
   return lastIdx > -1 ? stack.filter((_, idx) => idx !== lastIdx) : stack;
 }
 
-export function findNextBlankLetter(word: string[], startIndex: number): number {
+export function findNextBlankLetter(
+  word: string[],
+  startIndex: number
+): number {
   let count = 0;
   let index = startIndex % word.length;
   while (count < word.length) {
@@ -207,7 +210,10 @@ export default function Anagram() {
   const placeCircleLetter = (letterIndex: number, isDismissed: boolean) => {
     const character = letters[letterIndex].character;
     const updatedLetters = [...letters];
-    updatedLetters[letterIndex] = { ...updatedLetters[letterIndex], isDismissed };
+    updatedLetters[letterIndex] = {
+      ...updatedLetters[letterIndex],
+      isDismissed,
+    };
     setLetters(updatedLetters);
 
     if (isDismissed) {
@@ -216,9 +222,7 @@ export default function Anagram() {
 
       setNewWord(updatedWord);
       setUndoStack((prev) => [...prev, indexOfNewWord]);
-      setIndexOfNewWord(
-        findNextBlankLetter(updatedWord, indexOfNewWord)
-      );
+      setIndexOfNewWord(findNextBlankLetter(updatedWord, indexOfNewWord));
     } else {
       const index = newWord.lastIndexOf(character);
 
@@ -244,7 +248,10 @@ export default function Anagram() {
         (l) => l.character === character && l.isDismissed
       );
       if (letterIdx > -1) {
-        updatedLetters[letterIdx] = { ...updatedLetters[letterIdx], isDismissed: false };
+        updatedLetters[letterIdx] = {
+          ...updatedLetters[letterIdx],
+          isDismissed: false,
+        };
         setLetters(updatedLetters);
       }
 

--- a/app/routes/games/compare.$playerOne.$playerTwo.tsx
+++ b/app/routes/games/compare.$playerOne.$playerTwo.tsx
@@ -3,6 +3,7 @@ import { json, type LoaderFunctionArgs } from "@remix-run/server-runtime";
 import { format } from "date-fns";
 import invariant from "tiny-invariant";
 import { Card } from "~/components/Card";
+import { RecordCard } from "~/components/RecordCard";
 import type { GameType } from "~/models/game.server";
 import { getAllGames, getPlayer } from "~/models/game.server";
 import { enrichPlayerScores, type PlayerWithScores } from "~/game-utils";
@@ -199,69 +200,27 @@ export default function ComparePlayers() {
       {/* Card Grid */}
       <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
         {/* All-Time Record Card */}
-        <Card title="All-Time Record">
-          <div className="flex items-center justify-between">
-            <div className="text-center">
-              <div className="text-sm font-medium text-gray-600 dark:text-gray-400">
-                {loaderData.playerOne.name}
-              </div>
-              <div className="text-3xl font-bold text-blue-primary dark:text-blue-400">
-                {loaderData.playerOne.won}
-              </div>
-            </div>
-            <div className="text-2xl font-bold text-gray-400">-</div>
-            <div className="text-center">
-              <div className="text-sm font-medium text-gray-600 dark:text-gray-400">
-                {loaderData.playerTwo.name}
-              </div>
-              <div className="text-3xl font-bold text-blue-primary dark:text-blue-400">
-                {loaderData.playerTwo.won}
-              </div>
-            </div>
-            <div className="text-2xl font-bold text-gray-400">-</div>
-            <div className="text-center">
-              <div className="text-sm font-medium text-gray-600 dark:text-gray-400">
-                Draws
-              </div>
-              <div className="text-3xl font-bold text-gray-500 dark:text-gray-400">
-                {loaderData.draws}
-              </div>
-            </div>
-          </div>
-        </Card>
+        <RecordCard
+          title="All-Time Record"
+          p1Label={loaderData.playerOne.name}
+          p1Count={loaderData.playerOne.won}
+          p2Label={loaderData.playerTwo.name}
+          p2Count={loaderData.playerTwo.won}
+          draws={loaderData.draws}
+          color="blue"
+        />
 
         {/* Last 5 Games Card - Only show if more than 5 games played */}
         {loaderData.relevantGames.length > 5 && (
-          <Card title="Last 5 Games">
-            <div className="flex items-center justify-between">
-              <div className="text-center">
-                <div className="text-sm font-medium text-gray-600 dark:text-gray-400">
-                  {loaderData.playerOne.name}
-                </div>
-                <div className="text-3xl font-bold text-green-primary dark:text-green-400">
-                  {loaderData.playerOne.wonLastFive}
-                </div>
-              </div>
-              <div className="text-2xl font-bold text-gray-400">-</div>
-              <div className="text-center">
-                <div className="text-sm font-medium text-gray-600 dark:text-gray-400">
-                  {loaderData.playerTwo.name}
-                </div>
-                <div className="text-3xl font-bold text-green-primary dark:text-green-400">
-                  {loaderData.playerTwo.wonLastFive}
-                </div>
-              </div>
-              <div className="text-2xl font-bold text-gray-400">-</div>
-              <div className="text-center">
-                <div className="text-sm font-medium text-gray-600 dark:text-gray-400">
-                  Draws
-                </div>
-                <div className="text-3xl font-bold text-gray-500 dark:text-gray-400">
-                  {loaderData.drawsLastFive}
-                </div>
-              </div>
-            </div>
-          </Card>
+          <RecordCard
+            title="Last 5 Games"
+            p1Label={loaderData.playerOne.name}
+            p1Count={loaderData.playerOne.wonLastFive}
+            p2Label={loaderData.playerTwo.name}
+            p2Count={loaderData.playerTwo.wonLastFive}
+            draws={loaderData.drawsLastFive}
+            color="green"
+          />
         )}
 
         {/* Last Game Card */}


### PR DESCRIPTION
## Why

The All-Time Record and Last 5 Games cards on the compare page duplicated ~60 lines of identical 3-column layout JSX (player 1 wins, player 2 wins, draws). This duplication got worse when the Draws column was added in 12a78ef and will drift further with future changes.

This is a redo of #76 which was reverted in #77 due to a TypeScript error.

## What went wrong in PR #76

The `RecordCard` component typed `p1Label` and `p2Label` as `string`, but the loader data types them as `string | undefined` — because `getPlayer()` returns `Promise<{id, name} | null>`, and the loader does `(await getPlayer(...))?.name`. Passing `string | undefined` to a `string` prop is a TypeScript error.

**Why was the PR mergeable despite this?** The repo has **no branch protection rules** and **no required status checks** on `main`. CI runs on PRs, but nothing blocks the merge button — so the PR was merged before (or regardless of) the typecheck job result.

## The fix

`RecordCard` now accepts `p1Label: string | undefined` and `p2Label: string | undefined`, matching the actual loader data types. This is safe because JSX renders `undefined` as empty content.

## Visual changes

None — pure refactor.

## Test results

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run test -- --run` passes (148/148)
- [x] `npx prettier --check` passes

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)